### PR TITLE
Added Mp3 tagging support

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -161,7 +161,7 @@ function createConfig(options) {
 
 function ensureConfigExists() {
   if (!configManager.exists()) {
-    program.showHelpAfterError(chalk`{gray ${logSymbols.info} Try using the following command to create one:\n  {italic odm config -u example-username -p example-password -dl "./example/dowload/path" -l example-library-name}\n}`)
+    program.showHelpAfterError(chalk`{gray ${logSymbols.info} Try using the following command to create one:\n  {italic odm config -l example-library-name -u example-username -p example-password -dl "./example/dowload/path"}\n}`)
     program.error(chalk`Could not locate a configuration file: {bold ${configManager.configFilePath}}`);
   }
 }

--- a/cli.mjs
+++ b/cli.mjs
@@ -80,7 +80,7 @@ async function download(title) {
   const odmFilePath = await downloadOdm(title);  
   const downloadResults = await downloadMp3(odmFilePath);
   const renameResults = await rename({ path: downloadResults.bookPath, ...downloadResults.bookMetadata });
-  const tagResults = await tag({ path: renameResults.directoryPath, ...downloadResults.bookMetadata });
+  const tagResults = await tag({ path: renameResults.directory, ...downloadResults.bookMetadata });
   
   fs.rmSync(downloadResults.odmPath);
   fs.rmSync(downloadResults.licensePath);

--- a/mp3-files.mjs
+++ b/mp3-files.mjs
@@ -86,25 +86,30 @@ export default class Mp3Files {
     const renameDirectoryResult = await this.renameDirectory(bookMetadata, options);
     return {
       directory: renameDirectoryResult,
-      files: renameFilesResult
+      files: renameFilesResult.files,
+      bookMetadata: renameFilesResult.bookMetadata
     }
   }
 
   async renameFiles(bookMetadata, options) {
     let { filePattern, directoryPath } = this._getOptionsWithDefaults(options, bookMetadata);
-    const renameFilesResult = [];
 
     // Get all files in the path
     const pattern = path.join(directoryPath, this.filesGlobPattern)
     const files = await globby(pattern);
     bookMetadata.partCount = files.length;
 
+    const renameFilesResult = {
+      bookMetadata,
+      files: []
+    };
+
     // Rename each file
     for(let filePath of files) {
       const fileMetadata = _getFileMetadata(filePath);
       const newFilePath = _renameFile(filePattern, fileMetadata, bookMetadata);
       if (filePath !== newFilePath) {
-        renameFilesResult.push(newFilePath);
+        renameFilesResult.files.push(newFilePath);
       }
     }
 

--- a/mp3-tags.mjs
+++ b/mp3-tags.mjs
@@ -1,0 +1,97 @@
+import path from "path";
+import { globby } from "globby";
+import fillTemplate from "es6-dynamic-template";
+import NodeID3 from "node-id3";
+import Config from "./utils/config.mjs";
+import { title } from "process";
+
+export default class Mp3Tags {
+
+  titlePattern = "${title} - Part ${trackNumber}";
+  filesGlobPattern = "**{.mp3,.aac}";
+  defaultTags = {
+    genre: "Audiobooks",
+    comment: {
+      language: "eng"
+    }
+  }
+
+  constructor() {
+    this.configManager = new Config();
+    this.config = this.configManager.getConfig();
+    this._createDefaultConfig();
+  }
+
+  async normalizeTags(directoryPath, bookMetadata, options) {
+    this.config.titlePattern = options.titlePattern || this.config.titlePattern;
+    const pattern = path.join(directoryPath, this.filesGlobPattern);
+    const files = await globby(pattern);
+    bookMetadata.partCount = files.length;
+
+    const normalizeTagsResults = {
+      bookMetadata,
+      files: []
+    };
+
+    for (let filePath of files) {
+      const fileMetadata = _getFileMetadata(filePath);
+      const tags = this.mapMetadataToID3Tags(fileMetadata, bookMetadata);
+      const success = NodeID3.write(tags, filePath);
+      if (success) {
+        normalizeTagsResults.files.push(filePath);
+      }
+    }
+
+    return normalizeTagsResults;
+  }
+
+  mapMetadataToID3Tags(fileMetadata, bookMetadata) {
+    const partTitle = _getPartTitle(this.config.titlePattern, fileMetadata, bookMetadata);
+    const { genre, comment: { language }} = this.defaultTags;
+    const tags = {
+      artist: bookMetadata.author,
+      album: bookMetadata.title,
+      subtitle: bookMetadata.subTitle,
+      TSOA: bookMetadata.series,
+      comment: {
+        language,
+        text: bookMetadata.description
+      },
+      genre, 
+      title: partTitle,
+      trackNumber: fileMetadata.trackNumber
+    };
+    return tags;
+  }
+
+  _createDefaultConfig() {
+    let configChanged = false;
+
+    if (!this.config.titlePattern) {
+      this.config.titlePattern = this.titlePattern;
+      configChanged = true;
+    }
+    
+    if (configChanged) {
+      this.configManager.saveConfig(this.config);
+    }
+  }
+}
+
+function _getPartTitle(titlePattern, fileMetadata, bookMetadata) {
+  const values = { ...bookMetadata, ...fileMetadata };
+
+  // Pad the trackNumber with leading 0's
+  values.trackNumber = fileMetadata.trackNumber.padStart(bookMetadata.partCount.toString().length, "0");
+
+  const title = fillTemplate(titlePattern, values);
+  return title;
+}
+
+function _getFileMetadata(filePath) {
+  const directoryPath = path.dirname(filePath);
+  const fileExtension = path.extname(filePath);
+  const fileName = path.basename(filePath, fileExtension);
+  const trackNumber = fileName.replace(/.*\D(\d+)\D*/, "$1"); // Gets the last number in the fileName string
+  return { directoryPath, fileExtension, fileName, filePath, trackNumber };
+}

--- a/mp3-tags.mjs
+++ b/mp3-tags.mjs
@@ -39,10 +39,12 @@ export default class Mp3Tags {
     for (let filePath of files) {
       const fileMetadata = _getFileMetadata(filePath);
       const tags = this.mapMetadataToID3Tags(fileMetadata, bookMetadata);
-      const success = NodeID3.write(tags, filePath);
-      if (success) {
-        normalizeTagsResult.files.push(filePath);
+      const clearResponse = NodeID3.removeTags(filePath);
+      const writeResponse = NodeID3.write(tags, filePath);
+      if (writeResponse instanceof Error) {
+        throw writeResponse;
       }
+      normalizeTagsResult.files.push(filePath);
     }
 
     return normalizeTagsResult;

--- a/mp3-tags.mjs
+++ b/mp3-tags.mjs
@@ -23,7 +23,7 @@ export default class Mp3Tags {
   }
 
   async normalizeTags(directoryPath, bookMetadata, options) {
-    this.config.titlePattern = options.titlePattern || this.config.titlePattern;
+    this.config.titlePattern = options?.titlePattern || this.config.titlePattern;
 
     // Get all files in the path
     const pattern = path.join(directoryPath, this.filesGlobPattern);

--- a/odm-download.mjs
+++ b/odm-download.mjs
@@ -108,7 +108,7 @@ export default class OdmDownload {
     // Get the download button (relative to the title)
     const parent1 = await titleElement.getProperty('parentNode');
     const parent2 = await parent1.getProperty('parentNode');
-    const accordianButton = await parent2.$("a.accordian-title");
+    const accordianButton = await parent2.$("a.accordion-title");
     const downloadButton = await parent2.$("a.downloadButton");
 
     // Expand the accordian so that the download button is clickable

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "junk": "^4.0.0",
         "log-symbols": "^5.1.0",
         "log-update": "^5.0.0",
+        "node-id3": "^0.2.3",
         "puppeteer": "^13.1.2",
         "uuid": "^8.3.2",
         "xmldom": "^0.6.0",
@@ -562,6 +563,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -765,6 +777,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/node-id3": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/node-id3/-/node-id3-0.2.3.tgz",
+      "integrity": "sha512-HhaCaW6/nSwTxsTKtZiL7tqV9y1qCRjig37Ep3o0EEunpg1egda1vD6TRBpJb29oXPeLuzaWTaCLIQ9QRk52Ag==",
+      "dependencies": {
+        "iconv-lite": "0.6.2"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1046,6 +1066,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.6",
@@ -1692,6 +1717,14 @@
         "debug": "4"
       }
     },
+    "iconv-lite": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1822,6 +1855,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node-id3": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/node-id3/-/node-id3-0.2.3.tgz",
+      "integrity": "sha512-HhaCaW6/nSwTxsTKtZiL7tqV9y1qCRjig37Ep3o0EEunpg1egda1vD6TRBpJb29oXPeLuzaWTaCLIQ9QRk52Ag==",
+      "requires": {
+        "iconv-lite": "0.6.2"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1990,6 +2031,11 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "signal-exit": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "junk": "^4.0.0",
     "log-symbols": "^5.1.0",
     "log-update": "^5.0.0",
+    "node-id3": "^0.2.3",
     "puppeteer": "^13.1.2",
     "uuid": "^8.3.2",
     "xmldom": "^0.6.0",

--- a/tests/mp3-tags.tests.mjs
+++ b/tests/mp3-tags.tests.mjs
@@ -1,0 +1,18 @@
+import Mp3Tags from "../mp3-tags.mjs";
+
+const bookPath = "./downloads/Ernest Hemingway/The Old Man and the Sea";
+const bookMetadata = {
+  "author": "Ernest Hemingway",
+  "title": "The Old Man and the Sea",
+  "series": "",
+  "description": "This short novel, already a modern classic, is the superbly told, tragic story of a Cuban fisherman in the Gulf Stream and the giant Marlin he kills and loses—specifically referred to in the citation accompanying the author's Nobel Prize for literature in 1954.",
+  "partCount": 6
+}
+
+async function test() {
+  const tags = new Mp3Tags();
+  const result = await tags.normalizeTags(bookPath, bookMetadata);
+  console.log(result);
+}
+
+await test();

--- a/tests/mp3-tags.tests.mjs
+++ b/tests/mp3-tags.tests.mjs
@@ -8,10 +8,11 @@ const bookMetadata = {
   "description": "This short novel, already a modern classic, is the superbly told, tragic story of a Cuban fisherman in the Gulf Stream and the giant Marlin he kills and loses—specifically referred to in the citation accompanying the author's Nobel Prize for literature in 1954.",
   "partCount": 6
 }
+const options = { titlePattern: "${title} - Part ${trackNumber}" };
 
 async function test() {
   const tags = new Mp3Tags();
-  const result = await tags.normalizeTags(bookPath, bookMetadata);
+  const result = await tags.normalizeTags(bookPath, bookMetadata, options);
   console.log(result);
 }
 


### PR DESCRIPTION
After renaming files, the mp3 tags will be normalized with tags that fit the audiobook metadata.  This capability was added because the default tags were creating multiple albums for a single audiobook.  After this change applications like Plex will identify all the audiobook parts as a single book/album.