### PR TITLE
Made the password field optional

### DIFF
--- a/odm-download.mjs
+++ b/odm-download.mjs
@@ -130,7 +130,9 @@ export default class OdmDownload {
 
     // Enter username & password
     await this.page.type("#username", username);
-    await this.page.type("#password", password);
+    if (password !== "") {
+       await this.page.type("#password", password);
+    }
     await this.page.click(".signin-button")
   
     // If the url is the base url, assume the login succeded


### PR DESCRIPTION
Check if the user is using a password. If so enter it, if not skip looking for the password field.

Some libraries don't ask for a password, so there is no password field, and the application will end with an error: "Error: No node found for selector: #password". This pull request fixes that.

In order to use this for a library which doesn't require any password, when using docker-compose, leave the `- ODM_PASSWORD=` field in place, but do not add any password.